### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
-#Database
+# Database
 City state country dropdown : http://lab.iamrohit.in/php_ajax_country_state_city_dropdown/ 
 Download full source code: http://www.iamrohit.in/tag/php-ajax-country-state-city-dropdown
 
-#Note: 
+# Note: 
 *This Free database dose not guarantee for the complete list of world countries, states and cities.
 
 *You can manually change the spelling mistakes, or add edit any records, which are not correct.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
